### PR TITLE
added very basic authenitcation rememberance

### DIFF
--- a/pyvts/tests/integration/test_integration.py
+++ b/pyvts/tests/integration/test_integration.py
@@ -25,7 +25,7 @@ async def test_integration():
     assert myvts.get_connection_status() == 1
 
     # step 02
-    await myvts.request_authenticate_token()
+    await myvts.request_authenticate_token(force=True)
     assert myvts.get_authentic_status() == 1
 
     # step 04

--- a/pyvts/tests/test_vts.py
+++ b/pyvts/tests/test_vts.py
@@ -66,7 +66,7 @@ async def test_vts_authenticate(myvts: pyvts.vts):
     fake_server = FakeVtubeStudioAPIServer()
     await fake_server.start(port=PORT)
     await myvts.connect()
-    await myvts.request_authenticate_token()
+    await myvts.request_authenticate_token(force=True)
     assert myvts.get_authentic_status() == 1, myvts.authentic_token
     await myvts.request_authenticate()
     assert myvts.get_authentic_status() == 2


### PR DESCRIPTION
I noticed that the read_token and write_token were implemented but not currently being used. I have added a very basic way to use them. This does break if a user revokes access to the plugin in vtube studio, but that can be fixed by deleting the token file. I also added a force parameter for testing that way token files aren't used and we are forced to call the vtube studio api

This is still not the greatest way to do it and needs to be polished but it does work